### PR TITLE
Add `any`, `unknown` cases to `getConditionStatement`, and two other updates

### DIFF
--- a/src/codeGenerator/codeGenerator.ts
+++ b/src/codeGenerator/codeGenerator.ts
@@ -2,6 +2,7 @@ import { ImportDeclarationStructure, Project, SourceFile, StructureKind } from '
 import { AstRootNode, Dependencies } from '../reporterAst';
 import { generateBodyCode } from './generateBodyCode';
 import { makeAsync } from '../utils';
+import { isType } from './utils';
 
 export type CodeGenerator = {
     astRootNode: AstRootNode;
@@ -40,7 +41,7 @@ export const codeGenerator = async ({ astRootNode, project, outFilePath, inputSo
 
     const code = [
         `export const validate${pascalCasedName} = (value: unknown): GeneratedWrongTypeErrorReport | undefined => {`,
-        `    const typedValue = value as ${ast.name};`,
+        `    const typedValue = value as ${isType(ast.type) ? ast.type : ast.name};`,
         `    const error: GeneratedWrongTypeErrorReport = [];`,
         `    ${generateBodyCode({
             astNode: ast,

--- a/src/codeGenerator/generateBodyCode.ts
+++ b/src/codeGenerator/generateBodyCode.ts
@@ -347,5 +347,11 @@ const getConditionStatement = ({
         return `typeof ${getName(nameStack, namePrefix)} !== '${astNode.type}'`;
     }
 
-    return `${getName(nameStack, namePrefix)} !== ${astNode.type}`;
+    const untyped = ['any', 'unknown'];
+    if (untyped.includes(astNode.type)) {
+        return `false`;
+    }
+
+    /** reject by default */
+    return `true`;
 };

--- a/src/codeGenerator/generateBodyCode.ts
+++ b/src/codeGenerator/generateBodyCode.ts
@@ -347,6 +347,12 @@ const getConditionStatement = ({
         return `typeof ${getName(nameStack, namePrefix)} !== '${astNode.type}'`;
     }
 
+    /**
+     * This function returns the most appropriate condition statement,
+     * therefore for those types it returns pure boolean value.
+     *
+     * However the generated whole conditional expression would be useless.
+     */
     const untyped = ['any', 'unknown'];
     if (untyped.includes(astNode.type)) {
         return `false`;

--- a/src/codeGenerator/utils.ts
+++ b/src/codeGenerator/utils.ts
@@ -13,8 +13,26 @@ export const getName = (nameStack: string[], namePrefix?: string) => {
     return namePrefix ? `${namePrefix}${propertyChain(nameStack)}` : `typedValue${propertyChain(nameStack)}`;
 };
 
+export const isType = (nodeType: string) => {
+    const types = [
+        'string',
+        'number',
+        'bigint',
+        'boolean',
+        'symbol',
+        'undefined',
+        'null',
+        'undefined',
+        'any',
+        'unknown',
+        'never',
+    ];
+    return types.includes(nodeType);
+};
+
 const propertyChain = (nameStack: string[]) => {
     return nameStack.reduce((acc, curr) => {
         return `${acc}['${curr}']`;
     }, '');
 };
+


### PR DESCRIPTION
- Add `any`, `unknown` cases to `getConditionStatement`. (Actually `unknown` is unnecessary because `ts-morph` interprets `unknown` as `any`)
- Set default return value as `true` in `getConditionStatement` in order to reject type check by default.
- Fix type assertion in the generated guard file.